### PR TITLE
Fix vagrantfile to add 'vagrant' user to docker group

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,6 @@ Vagrant.configure("2") do |config|
     curl -sSL https://get.docker.com/ | sh
     service docker start
 
-    usermod -aG docker ubuntu
+    usermod -aG docker vagrant
   SHELL
 end


### PR DESCRIPTION
Vagrant boxes always set up the 'vagrant' user. Couldn't run docker.